### PR TITLE
Load Groq key from env

### DIFF
--- a/backend/env-example.txt
+++ b/backend/env-example.txt
@@ -4,7 +4,7 @@ REDIS_PORT=6379
 REDIS_PASSWORD=
 
 # API Keys
-GROQ_API_KEY=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
+GROQ_API_KEY=your_key_here
 # Get your free API key at: https://console.groq.com/keys
 
 # Future APIs

--- a/backend/main.py
+++ b/backend/main.py
@@ -303,7 +303,7 @@ async def query_urbanisme(request: QueryRequest):
             if snippets:
                 context = "\n\n".join(f"[Snippet {i+1}]: {s}" for i, s in enumerate(snippets))
 
-        answer = await generate_llm_answer(request.question, context)
+        answer = await generate_llm_answer(request.question, context, GROQ_API_KEY)
 
         confidence = None
         

--- a/backend/rag_utils.py
+++ b/backend/rag_utils.py
@@ -1,4 +1,3 @@
-import os
 import json
 from pathlib import Path
 from typing import List
@@ -10,9 +9,6 @@ import PyPDF2
 from dotenv import load_dotenv
 
 load_dotenv()
-
-# Groq API key
-GROQ_API_KEY = os.getenv("GROQ_API_KEY", "")
 
 # Embedding model
 MODEL_NAME = "all-MiniLM-L6-v2"
@@ -105,13 +101,13 @@ def retrieve_context(question: str, top_k: int = 5) -> List[str]:
     return snippets
 
 
-async def generate_llm_answer(question: str, context: str) -> str:
+async def generate_llm_answer(question: str, context: str, api_key: str) -> str:
     """Call the Groq API using httpx and return the answer."""
-    if not GROQ_API_KEY:
+    if not api_key:
         return ""
 
     url = "https://api.groq.com/openai/v1/chat/completions"
-    headers = {"Authorization": f"Bearer {GROQ_API_KEY}"}
+    headers = {"Authorization": f"Bearer {api_key}"}
 
     messages = [
         {


### PR DESCRIPTION
## Summary
- add GROQ_API_KEY placeholder to env-example.txt
- read GROQ_API_KEY in backend/main.py
- pass the key to `generate_llm_answer`
- update `rag_utils.generate_llm_answer` to accept key

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bcd4cd45c83229e90ad7350a96ee7