### PR TITLE
Add LLM integration with RAG

### DIFF
--- a/backend/env-example.txt
+++ b/backend/env-example.txt
@@ -8,3 +8,7 @@ GPU_API_KEY=your_api_key_here
 
 # Environment
 ENVIRONMENT=development
+
+# OpenAI / Vector Store
+OPENAI_API_KEY=
+VECTOR_STORE_PATH=./vector_store

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,3 +4,6 @@ httpx==0.25.0
 python-dotenv==1.0.0
 redis==5.0.1
 pydantic==2.4.2
+langchain
+faiss-cpu
+openai

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,17 @@
+import json
+from fastapi.testclient import TestClient
+import backend.main as main
+
+client = TestClient(main.app)
+
+def test_query_returns_answer(monkeypatch):
+    def fake_llm(question: str, commune=None):
+        return "LLM response"
+
+    monkeypatch.setattr(main, "generate_llm_response", fake_llm)
+    response = client.post("/api/query", json={"question": "Test?", "commune": "X"})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["answer"] == "LLM response"
+    assert data["answer"]
+


### PR DESCRIPTION
## Summary
- integrate optional LLM answering using a FAISS vector store
- switch `/api/query` to use the new generator with mock fallback
- document OPENAI variables in env-example
- add langchain, faiss-cpu and openai to requirements
- test API answer via monkeypatched LLM

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_684bd72cdd1c83228f123c5d0348c5cb