### PR TITLE
Document RAG setup

### DIFF
--- a/backend/build_index.py
+++ b/backend/build_index.py
@@ -1,0 +1,47 @@
+import os
+import sys
+from pathlib import Path
+from typing import List
+
+from langchain.document_loaders import TextLoader
+from langchain.text_splitter import RecursiveCharacterTextSplitter
+from langchain.embeddings import OpenAIEmbeddings
+from langchain.vectorstores import FAISS
+
+
+def load_documents(folder: Path) -> List[str]:
+    """Load all .txt files from the folder."""
+    docs = []
+    for file in folder.rglob('*.txt'):
+        loader = TextLoader(str(file), encoding='utf-8')
+        docs.extend(loader.load())
+    return docs
+
+
+def main():
+    if len(sys.argv) < 3:
+        print('Usage: python build_index.py <docs_folder> <index_path>')
+        sys.exit(1)
+
+    docs_folder = Path(sys.argv[1])
+    index_path = Path(sys.argv[2])
+
+    api_key = os.getenv('OPENAI_API_KEY')
+    if not api_key:
+        print('OPENAI_API_KEY not set in environment')
+        sys.exit(1)
+
+    raw_docs = load_documents(docs_folder)
+    splitter = RecursiveCharacterTextSplitter(chunk_size=500, chunk_overlap=50)
+    docs = splitter.split_documents(raw_docs)
+
+    embeddings = OpenAIEmbeddings(openai_api_key=api_key)
+    vector_store = FAISS.from_documents(docs, embeddings)
+
+    index_path.parent.mkdir(parents=True, exist_ok=True)
+    vector_store.save_local(str(index_path))
+    print(f'Index saved to {index_path}')
+
+
+if __name__ == '__main__':
+    main()

--- a/backend/env-example.txt
+++ b/backend/env-example.txt
@@ -10,5 +10,7 @@ GPU_API_KEY=your_api_key_here
 ENVIRONMENT=development
 
 # OpenAI / Vector Store
+# Clé API OpenAI pour générer les embeddings et répondre aux requêtes
 OPENAI_API_KEY=
+# Chemin vers l'index FAISS généré via build_index.py
 VECTOR_STORE_PATH=./data/index.faiss

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,3 +7,4 @@ pydantic==2.4.2
 langchain
 faiss-cpu
 openai
+tqdm

--- a/readme.md
+++ b/readme.md
@@ -28,11 +28,40 @@ Test complet de l'application sur votre PC Windows en local, sans déploiement c
 - Message "Installation terminée !" s'affiche
 
 ### 4. **Configuration IA**
-Ajoutez vos clés dans `/backend/.env` :
+Ajoutez vos clés dans `/backend/.env` et configurez l'index vectoriel :
 
 ```env
 OPENAI_API_KEY=
 VECTOR_STORE_PATH=./data/index.faiss
+```
+
+Installez également les dépendances LLM/RAG (langchain, faiss-cpu, openai, tqdm)
+si ce n'est pas déjà fait :
+
+```bash
+cd backend
+venv\Scripts\activate  # ou `source venv/bin/activate` sous Linux/Mac
+pip install -r requirements.txt
+```
+
+#### Construction de l'index FAISS
+
+Placez vos documents `.txt` dans un dossier (par ex. `./docs`) puis générez
+l'index vectoriel :
+
+```bash
+python build_index.py ./docs ./data/index.faiss
+```
+
+L'API détectera automatiquement l'index et utilisera le mode RAG pour répondre
+aux questions si `OPENAI_API_KEY` est défini.
+
+Exemple de démarrage manuel du backend avec RAG activé :
+
+```bash
+cd backend
+venv\Scripts\activate
+uvicorn main:app --reload
 ```
 
 ---


### PR DESCRIPTION
## Summary
- document RAG/LLM setup and dependencies in the README
- enhance `.env.example` comments
- add `tqdm` dependency
- provide `build_index.py` helper to create FAISS index

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_684bdc344f6c8322affa0b152b3bcfd4