### PR TITLE
Update requirements

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,8 +3,9 @@ uvicorn==0.24.0
 httpx==0.25.0
 python-dotenv==1.0.0
 redis==5.0.1
-pydantic==2.4.2
-langchain
+pydantic==1.10.13
+langchain==0.1.13
+langsmith==0.0.70
 faiss-cpu
 openai
 tqdm


### PR DESCRIPTION
## Summary
- pin pydantic to 1.10.13
- pin langchain to 0.1.13
- add langsmith 0.0.70

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_684ca932556c8322963e617f346951f6