### PR TITLE
Update env-example with LLM settings

### DIFF
--- a/backend/env-example.txt
+++ b/backend/env-example.txt
@@ -14,3 +14,11 @@ ENVIRONMENT=development
 OPENAI_API_KEY=
 # Chemin vers l'index FAISS généré via build_index.py
 VECTOR_STORE_PATH=./data/index.faiss
+
+# LLM Configuration
+# Provider can be 'openai', 'ollama', 'lm_studio', etc.
+LLM_PROVIDER=openai
+# Model name or path
+LLM_MODEL=
+# Embeddings model (optional)
+EMBEDDINGS_MODEL=


### PR DESCRIPTION
## Summary
- add config options for LLM provider and models in `env-example.txt`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_684cbd5846f0832287a7e7b00dec091d