### PR TITLE
Add RAG pipeline with provider switch

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -10,16 +10,11 @@ import os
 from dotenv import load_dotenv
 import logging
 import time
+
 try:
-    from langchain.embeddings import OpenAIEmbeddings
-    from langchain.llms import OpenAI
-    from langchain.vectorstores import FAISS
-    import openai
-except ImportError:  # Dependencies may be missing in some environments
-    OpenAIEmbeddings = None
-    OpenAI = None
-    FAISS = None
-    openai = None
+    from services.rag import build_rag_pipeline
+except Exception:  # Module may not be available during minimal tests
+    build_rag_pipeline = None
 
 # Configuration
 load_dotenv()
@@ -203,32 +198,14 @@ async def clear_cache():
         return {"message": "Cache non activé"}
 
 def generate_llm_response(question: str, commune: Optional[str] = None) -> str:
-    """Interroge un LLM à l'aide d'un contexte récupéré depuis un vecteur store."""
-    if not (OpenAIEmbeddings and OpenAI and FAISS):
-        raise ImportError("LLM dependencies are not installed")
+    """Interroge le pipeline RAG configuré pour obtenir une réponse."""
+    if build_rag_pipeline is None:
+        raise ImportError("RAG pipeline unavailable")
 
-    api_key = os.getenv("OPENAI_API_KEY")
-    if not api_key:
-        raise ValueError("OPENAI_API_KEY not set")
-
-    embeddings = OpenAIEmbeddings(openai_api_key=api_key)
-    store_path = os.getenv("VECTOR_STORE_PATH", "vector_store")
-
-    docs = []
-    if os.path.exists(store_path):
-        try:
-            vs = FAISS.load_local(store_path, embeddings)
-            docs = vs.similarity_search(question, k=4)
-        except Exception as e:
-            logger.warning(f"Vector store load failed: {e}")
-
-    context = "\n".join([d.page_content for d in docs])
-    prompt = (
-        "Réponds à la question suivante en utilisant le contexte fourni s'il est disponible.\n"
-        f"Contexte:\n{context}\n\nQuestion: {question}"
-    )
-    llm = OpenAI(openai_api_key=api_key, temperature=0)
-    return llm.predict(prompt).strip()
+    chain = build_rag_pipeline()
+    query = question if not commune else f"{question}\nCommune: {commune}"
+    result = chain({"query": query})
+    return result.get("result", "")
 
 def generate_mock_response(question: str, commune: Optional[str] = None) -> str:
     """

--- a/backend/services/rag.py
+++ b/backend/services/rag.py
@@ -1,0 +1,58 @@
+import os
+from typing import Optional
+from dotenv import load_dotenv
+
+from langchain.chains import RetrievalQA
+from langchain.embeddings import OpenAIEmbeddings
+from langchain.llms import OpenAI, Ollama
+from langchain.chat_models import ChatOpenAI
+from langchain.vectorstores import FAISS
+
+load_dotenv()
+
+_PIPELINE: Optional[RetrievalQA] = None
+
+
+def _get_llm() -> object:
+    provider = os.getenv("LLM_PROVIDER", "openai").lower()
+    model = os.getenv("LLM_MODEL", "")
+
+    if provider == "openai":
+        api_key = os.getenv("OPENAI_API_KEY")
+        if not api_key:
+            raise ValueError("OPENAI_API_KEY not set")
+        return OpenAI(openai_api_key=api_key, model_name=model or None, temperature=0)
+
+    if provider == "ollama":
+        return Ollama(model=model or "llama2")
+
+    if provider in {"lmstudio", "lm_studio"}:
+        base_url = os.getenv("LM_STUDIO_BASE_URL", "http://localhost:1234/v1")
+        api_key = os.getenv("LM_STUDIO_API_KEY", "lm-studio")
+        return ChatOpenAI(openai_api_base=base_url, openai_api_key=api_key, model=model or None, temperature=0)
+
+    raise ValueError(f"Unsupported LLM_PROVIDER: {provider}")
+
+
+def build_rag_pipeline() -> RetrievalQA:
+    """Create and return a RetrievalQA chain using the configured provider."""
+    global _PIPELINE
+    if _PIPELINE:
+        return _PIPELINE
+
+    embeddings_key = os.getenv("OPENAI_API_KEY")
+    if not embeddings_key:
+        raise ValueError("OPENAI_API_KEY not set for embeddings")
+
+    embeddings = OpenAIEmbeddings(openai_api_key=embeddings_key)
+    store_path = os.getenv("VECTOR_STORE_PATH", "vector_store")
+
+    if not os.path.exists(store_path):
+        raise FileNotFoundError(f"Vector store not found at {store_path}")
+
+    vector_store = FAISS.load_local(store_path, embeddings)
+    retriever = vector_store.as_retriever(search_kwargs={"k": 4})
+    llm = _get_llm()
+
+    _PIPELINE = RetrievalQA.from_chain_type(llm, chain_type="stuff", retriever=retriever)
+    return _PIPELINE


### PR DESCRIPTION
## Summary
- add RAG service with `build_rag_pipeline`
- wire API to use this chain in `generate_llm_response`
- allow choosing between OpenAI, Ollama or LM Studio via environment variables

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_684cbdf1d5e0832298a71c6eff35d199