### PR TITLE
Add test dependencies list

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -42,6 +42,14 @@ si ce n'est pas déjà fait :
 cd backend
 venv\Scripts\activate  # ou `source venv/bin/activate` sous Linux/Mac
 pip install -r requirements.txt
+
+```
+
+### Installation des dépendances de test
+Si vous souhaitez exécuter les tests, installez également :
+
+```bash
+pip install -r requirements-test.txt
 ```
 
 #### Construction de l'index FAISS

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,2 @@
+httpx
+pytest


### PR DESCRIPTION
## Summary
- create `requirements-test.txt` with httpx and pytest
- document how to install test requirements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pip install -r backend/requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi==0.104.1)*

------
https://chatgpt.com/codex/tasks/task_e_684cc1ef89088322890aaf0f06f3bf9d