### PR TITLE
Add PyPDF2 to backend requirements

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -23,3 +23,4 @@ groq==0.27.0
 chromadb==1.0.12
 tiktoken==0.9.0
 
+PyPDF2>=3.0.0


### PR DESCRIPTION
## Summary
- include PyPDF2 in backend requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ce5dcb8fc8322b98a8295aefb6676