### PR TITLE
Fix README line reference

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -51,7 +51,7 @@ docker-compose up --build
 ### Frontend (Vercel)
 1. Importer sur Vercel
 2. Root directory : `frontend`
-3. Modifier `API_URL` dans index.html : L594
+3. Modifier `API_URL` dans index.html : ligne 131
   const API_URL = window.location.hostname === 'localhost' 
             ? 'http://localhost:8000' 
             : localpctest-esemple.up.railway.app;


### PR DESCRIPTION
## Summary
- correct the API_URL line reference in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ce7edfae88322a01d1f64c623e4ea