### PR TITLE
Fix env example path in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -25,8 +25,8 @@ cd LocalPCTest-BOT-ARCHI-URBA
 install.bat
 
 # 3. Configurer Groq
-# Copier backend/.env.example vers backend/.env
-# Ajouter votre clé Groq : https://console.groq.com/keys
+# Copier backend/env-example.txt vers backend/.env
+# Puis ajoutez votre clé Groq : https://console.groq.com/keys
 
 # 4. Lancer
 start.bat


### PR DESCRIPTION
## Summary
- reference `backend/env-example.txt` in the quick start instructions
- explain copying it to `.env` before adding keys

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cf05a00e88322aa744cb90e2f925f