### PR TITLE
Fix PDF BytesIO usage

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -13,6 +13,7 @@ import time
 import chromadb
 from chromadb.utils import embedding_functions
 import PyPDF2
+import io
 import docx
 from groq import Groq
 import tiktoken
@@ -106,7 +107,7 @@ class StatsResponse(BaseModel):
 def extract_text_from_pdf(file_content: bytes) -> str:
     """Extrait le texte d'un PDF"""
     try:
-        pdf_reader = PyPDF2.PdfReader(file_content)
+        pdf_reader = PyPDF2.PdfReader(io.BytesIO(file_content))
         text = ""
         for page in pdf_reader.pages:
             text += page.extract_text() + "\n"

--- a/tests/test_pdf_extract.py
+++ b/tests/test_pdf_extract.py
@@ -1,0 +1,27 @@
+import io
+import ast
+import types
+from pathlib import Path
+
+def get_extract_function(dummy_reader):
+    source = Path('backend/main.py').read_text()
+    tree = ast.parse(source)
+    func_node = next(node for node in tree.body if isinstance(node, ast.FunctionDef) and node.name == 'extract_text_from_pdf')
+    mod = ast.Module(body=[func_node], type_ignores=[])
+    code = compile(mod, filename='<ast>', mode='exec')
+    namespace = {'PyPDF2': types.SimpleNamespace(PdfReader=dummy_reader), 'io': io, 'logger': types.SimpleNamespace(error=lambda *a, **k: None)}
+    exec(code, namespace)
+    return namespace['extract_text_from_pdf']
+
+def test_extract_text_from_pdf_uses_bytesio():
+    captured = {}
+    def dummy_reader(file_obj):
+        captured['type'] = type(file_obj)
+        class DummyPage:
+            def extract_text(self_inner):
+                return 'hello'
+        return types.SimpleNamespace(pages=[DummyPage()])
+    func = get_extract_function(dummy_reader)
+    text = func(b'dummy')
+    assert text.strip() == 'hello'
+    assert captured['type'] is io.BytesIO


### PR DESCRIPTION
## Summary
- make `extract_text_from_pdf` wrap bytes using `io.BytesIO`
- add unit test checking that BytesIO is used

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cf361978c83229bbb30a482aa9411