### PR TITLE
Ignore Chroma DB directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,9 @@ yarn-error.log*
 # ------------------------
 .railway/
 .vercel/
+
+# ------------------------
+# 🔹 Bases de données
+# ------------------------
+# Dossier utilisé par ChromaDB pour persister les vecteurs du RAG
+backend/chroma_db/


### PR DESCRIPTION
## Summary
- update `.gitignore` to ignore backend `chroma_db` directory
- document purpose of Chroma persistent storage

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_684cf69b9b108322b4eb2fbdea91ccd2