### PR TITLE
Fix remote URL quoting

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -128,9 +128,9 @@ Comment puis-je vous aider aujourd'hui ?
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
     <script>
         // Configuration
-        const API_URL = window.location.hostname === 'localhost' 
-            ? 'http://localhost:8000' 
-            : localpctest-bot-archi-urba-test.up.railway.app;
+        const API_URL = window.location.hostname === 'localhost'
+            ? 'http://localhost:8000'
+            : 'https://localpctest-bot-archi-urba-test.up.railway.app';
         
         // État
         let isLoading = false;

--- a/readme.md
+++ b/readme.md
@@ -53,8 +53,8 @@ docker-compose up --build
 2. Root directory : `frontend`
 3. Modifier `API_URL` dans index.html : ligne 131
   const API_URL = window.location.hostname === 'localhost' 
-            ? 'http://localhost:8000' 
-            : localpctest-esemple.up.railway.app;
+            ? 'http://localhost:8000'
+            : 'https://localpctest-bot-archi-urba-test.up.railway.app';
 4. Deploy!
 
 ## 🔑 Obtenir Groq API Key


### PR DESCRIPTION
## Summary
- quote the remote API URL in frontend
- document the remote API URL in README

## Testing
- `pip install httpx`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684d1cab599c8322b447032b79cce41d