### PR TITLE
Fix asset resolution in vercel config

### DIFF
--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -9,6 +9,7 @@
     }
   ],
   "routes": [
+    { "handle": "filesystem" },
     {
       "src": "/(.*)",
       "dest": "/index.html"


### PR DESCRIPTION
## Summary
- add `handle: filesystem` rule before the SPA rewrite in `frontend/vercel.json`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d6349c47483229d0c2395fb825a28