### PR TITLE
Fix docx extraction

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -116,7 +116,8 @@ def extract_text_from_pdf(file_content: bytes) -> str:
 def extract_text_from_docx(file_content: bytes) -> str:
     """Extrait le texte d'un DOCX"""
     try:
-        doc = docx.Document(io.BytesIO(file_content))
+        buffer = io.BytesIO(file_content)
+        doc = docx.Document(buffer)
         text = ""
         for paragraph in doc.paragraphs:
             text += paragraph.text + "\n"

--- a/tests/test_docx_extract.py
+++ b/tests/test_docx_extract.py
@@ -2,6 +2,7 @@ import io
 import ast
 import types
 from pathlib import Path
+from docx import Document
 
 def get_extract_function(dummy_doc):
     source = Path('backend/main.py').read_text()
@@ -24,3 +25,14 @@ def test_extract_text_from_docx_uses_bytesio():
     text = func(b'dummy')
     assert text.strip() == 'hello'
     assert captured['type'] is io.BytesIO
+
+
+def test_extract_text_from_docx_with_real_bytes():
+    buffer = io.BytesIO()
+    doc = Document()
+    doc.add_paragraph("hello world")
+    doc.save(buffer)
+
+    func = get_extract_function(Document)
+    text = func(buffer.getvalue())
+    assert "hello world" in text


### PR DESCRIPTION
## Summary
- ensure `extract_text_from_docx` wraps content in `BytesIO`
- extend unit tests to read real DOCX bytes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d9d2ba7b08322a0a464e83c309603