### PR TITLE
Remove three.js mentions from docs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,6 @@
 
 ### Frontend futuriste
 - **Design cyberpunk** : Néon, glassmorphism
-- **Three.js 3D** : Particules animées
 - **Interface interactive** : Animations fluides
 - **Dashboard stats** : Temps réel
 
@@ -112,8 +111,6 @@ model="mixtral-8x7b-32768"  # Par défaut
 ### Modifier le style
 Dans `index.html` :
 - Variables CSS `--primary-neon`, `--secondary-neon`
-- Animations Three.js ligne ~370
-- Effets particules ligne ~350
 
 ## 📊 Monitoring
 
@@ -156,4 +153,4 @@ séparés pour évaluer la charge de l'API.
 ---
 
 **Support** : Créer une issue sur GitHub
-**Stack** : FastAPI + ChromaDB + Groq + Three.js
+**Stack** : FastAPI + ChromaDB + Groq


### PR DESCRIPTION
## Summary
- remove Three.js 3D mention and instructions from the README
- update stack list accordingly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dd33351708322852ae32926cb86cb