### PR TITLE
Add configurable CORS origins

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -7,6 +7,9 @@ REDIS_PASSWORD=
 GROQ_API_KEY=gsk_YOUR_GROQ_API_KEY_HERE
 # Get your free API key at: https://console.groq.com/keys
 
+# Comma-separated list of origins allowed for CORS
+ALLOWED_ORIGINS=*
+
 # Future APIs
 SOGEFI_API_KEY=
 GPU_API_KEY=

--- a/backend/main.py
+++ b/backend/main.py
@@ -23,12 +23,19 @@ load_dotenv()
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+# Read allowed CORS origins from .env (comma separated)
+origins_env = os.getenv("ALLOWED_ORIGINS")
+if origins_env:
+    allowed_origins = [o.strip() for o in origins_env.split(',') if o.strip()]
+else:
+    allowed_origins = ["*"]
+
 app = FastAPI(title="Assistant Urbanisme AI", version="2.0.0")
 
 # CORS pour le frontend
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=allowed_origins,
     allow_methods=["*"],
     allow_headers=["*"],
 )

--- a/readme.md
+++ b/readme.md
@@ -28,6 +28,7 @@ pip install -r backend/requirements.txt
 # 3. Configurer Groq
 cp backend/.env.example backend/.env
 # puis ajoutez votre clé Groq : https://console.groq.com/keys
+# vous pouvez aussi définir `ALLOWED_ORIGINS` (liste séparée par des virgules)
 
 # 4. Lancer le serveur
 python backend/main.py
@@ -43,6 +44,7 @@ python backend/main.py
    ```
    GROQ_API_KEY=gsk_votre_cle_groq
    REDIS_URL=${{Redis.REDIS_URL}}  # Si Redis ajouté
+   ALLOWED_ORIGINS=*  # Liste d'origines séparées par des virgules
    ```
 5. Deploy!
 


### PR DESCRIPTION
## Summary
- allow configuring `ALLOWED_ORIGINS` in backend via `.env`
- document the new variable in README and `.env.example`

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dd9acd8688322b2a461b886d33b79