### PR TITLE
Sanitize chat message rendering

### DIFF
--- a/frontend/js/main.js
+++ b/frontend/js/main.js
@@ -135,17 +135,24 @@ function addMessage(content, type, id = null, badges = []) {
     const messageDiv = document.createElement('div');
     messageDiv.className = `message ${type}`;
     if (id) messageDiv.id = `msg-${id}`;
-    
-    let badgesHtml = '';
+
+    const contentDiv = document.createElement('div');
+    contentDiv.className = 'message-content';
+    contentDiv.textContent = content;
+    messageDiv.appendChild(contentDiv);
+
     if (badges.length > 0) {
-        badgesHtml = badges.map(badge => `<span class="source-badge">${badge}</span>`).join('');
+        const metaDiv = document.createElement('div');
+        metaDiv.className = 'message-meta';
+        badges.forEach(badge => {
+            const badgeSpan = document.createElement('span');
+            badgeSpan.className = 'source-badge';
+            badgeSpan.textContent = badge;
+            metaDiv.appendChild(badgeSpan);
+        });
+        messageDiv.appendChild(metaDiv);
     }
-    
-    messageDiv.innerHTML = `
-        <div class="message-content">${content}</div>
-        ${badgesHtml ? `<div class="message-meta">${badgesHtml}</div>` : ''}
-    `;
-    
+
     messagesDiv.appendChild(messageDiv);
     messagesDiv.scrollTop = messagesDiv.scrollHeight;
 }

--- a/tests/node_test.js
+++ b/tests/node_test.js
@@ -1,0 +1,18 @@
+const fs = require('fs');
+const { JSDOM } = require('jsdom');
+
+const code = fs.readFileSync('frontend/js/main.js', 'utf8');
+const match = code.match(/function addMessage\(.*?\{[\s\S]*?\n\}/);
+if (!match) throw new Error('addMessage not found');
+const addMessageCode = match[0];
+
+const dom = new JSDOM('<!DOCTYPE html><div id="chatMessages"></div>');
+const { window } = dom;
+
+const addMessage = new Function('window','document', `${addMessageCode}; return addMessage;`)(window, window.document);
+
+addMessage('<img id="xss" src="x" onerror="global.malicious=true">', 'user');
+
+const hasImg = window.document.querySelector('#xss') !== null;
+const contentHTML = window.document.querySelector('.message-content').innerHTML.trim();
+console.log(JSON.stringify({hasImg, contentHTML}));

--- a/tests/test_add_message.py
+++ b/tests/test_add_message.py
@@ -1,0 +1,19 @@
+import json
+import subprocess
+from pathlib import Path
+
+
+def ensure_jsdom():
+    """Install jsdom locally if it's not available."""
+    check_cmd = ['node', '-e', 'require("jsdom")']
+    if subprocess.run(check_cmd, capture_output=True).returncode != 0:
+        subprocess.run(['npm', 'install', 'jsdom'], check=True)
+
+
+def test_add_message_sanitizes_html():
+    ensure_jsdom()
+    script = Path(__file__).with_name('node_test.js')
+    result = subprocess.run(['node', str(script)], capture_output=True, text=True, check=True)
+    data = json.loads(result.stdout.strip())
+    assert data['hasImg'] is False
+    assert '&lt;img' in data['contentHTML']


### PR DESCRIPTION
## Summary
- prevent HTML injection in the chat by building DOM nodes
- add Node script for verifying message sanitization
- test via pytest to ensure no raw HTML is executed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dda5a101c8322a82ba6cc2e595d0d