### PR TITLE
Add project quick actions and 3D preview hooks

### DIFF
--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -253,6 +253,28 @@ body {
     display: none;
 }
 
+/* Quick actions */
+.quick-actions {
+    display: flex;
+    gap: 10px;
+    margin-bottom: 10px;
+}
+
+.quick-action {
+    background: rgba(0, 224, 255, 0.1);
+    border: 1px solid var(--primary-neon);
+    color: var(--primary-neon);
+    padding: 6px 12px;
+    border-radius: 15px;
+    cursor: pointer;
+    font-size: 0.875rem;
+    transition: background 0.3s;
+}
+
+.quick-action:hover {
+    background: rgba(0, 224, 255, 0.2);
+}
+
 /* Right Panel - Info */
 .info-panel {
     flex: 1;
@@ -374,6 +396,33 @@ body {
 .document-size {
     font-size: 0.875rem;
     color: var(--text-secondary);
+}
+
+/* Project cards */
+.project-card {
+    background: rgba(0, 224, 255, 0.05);
+    border: 1px solid rgba(0, 224, 255, 0.2);
+    border-radius: 10px;
+    padding: 10px;
+    margin-bottom: 10px;
+    cursor: pointer;
+}
+
+.project-card:hover {
+    background: rgba(0, 224, 255, 0.1);
+}
+
+.preview-3d {
+    height: 150px;
+    background: rgba(0, 224, 255, 0.05);
+    border: 1px solid rgba(0, 224, 255, 0.2);
+    margin-top: 10px;
+    border-radius: 10px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--text-secondary);
+    font-size: 0.875rem;
 }
 
 /* Loading Animation */

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -41,7 +41,11 @@ Comment puis-je vous aider aujourd'hui ?
                         </div>
                     </div>
                     <div class="input-area">
-                        <div class="input-wrapper">
+                        <div class="quick-actions">
+                            <button class="quick-action" data-action="Résumé du projet">Résumé</button>
+                            <button class="quick-action" data-action="Contraintes réglementaires">Contraintes</button>
+                        </div>
+                        <div class="input-wrapper" id="uploadZone">
                             <input type="file" id="fileInput" accept=".pdf,.docx,.txt" style="display:none;">
                             <button class="upload-button" onclick="document.getElementById('fileInput').click()">📁 Upload</button>
                             <input type="text" class="chat-input" id="chatInput" placeholder="Posez votre question sur l'urbanisme..." onkeypress="if(event.key === 'Enter' && !event.shiftKey) sendMessage()">
@@ -116,6 +120,12 @@ Comment puis-je vous aider aujourd'hui ?
                         <div id="documentsList">
                             <div style="color: var(--text-secondary); text-align: center; padding: 20px;">Aucun document uploadé</div>
                         </div>
+                    </div>
+                    <div class="panel-section" id="projectsPanel">
+                        <h3 class="section-title">🏗️ Projets</h3>
+                        <div id="projectList"></div>
+                        <button class="cyber-button" id="addStudyBtn">+ Étude de Faisabilité</button>
+                        <div id="preview3d" class="preview-3d"></div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- extend layout with quick-action buttons and project panel
- support drag & drop file uploads
- add project card styles
- add `quickAction`, `addFeasibilityStudy`, `init3DPreview` and event listeners
- allow safe HTML via optional flag in `addMessage`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684de8fa1e9c8322b5a22f406b4e9096