### PR TITLE
Update API URL configuration

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -787,9 +787,9 @@ Comment puis-je vous assister aujourd'hui ?
 
     <script>
         // Configuration
-        const API_URL = window.location.hostname === 'localhost' 
-            ? 'http://localhost:8000' 
-            : 'https://your-api-url.com';
+        const API_URL = window.location.hostname === 'localhost'
+            ? 'http://localhost:8000'
+            : 'https://striking-clarity-actelle.up.railway.app';
 
         // State
         let isLoading = false;

--- a/readme.md
+++ b/readme.md
@@ -65,7 +65,8 @@ python backend/main.py
      ```
      puis ajoutez `<script src="config.js"></script>` avant `js/main.js` dans `index.html`.
    - **Production** : dans Vercel, ajoutez une variable d'environnement `API_URL`
-     pointant vers votre backend. Elle sera injectée en tant que `window.ENV.API_URL`.
+     pointant vers votre backend (par ex. `https://striking-clarity-actelle.up.railway.app`).
+     Elle sera injectée en tant que `window.ENV.API_URL`.
    Le code lit automatiquement cette valeur dans `frontend/js/main.js` et revient
    au comportement précédent si elle est absente.
 4. Deploy!


### PR DESCRIPTION
## Summary
- update `index.html` to use the hosted backend
- clarify production API URL in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f01fb9b98832287c6e5186025abc2